### PR TITLE
Set custom layouts on configuration

### DIFF
--- a/examples/index.htm
+++ b/examples/index.htm
@@ -28,8 +28,17 @@
     <script src="../lib/js/jkeyboard.js"></script>
     <script>
         $('#keyboard').jkeyboard({
-          layout: "azeri",
-          input: $('#search_field')
+            layout: "english_capital",
+            input: $('#search_field'),
+            customLayouts: {
+                selectable: ["english_capital"],
+                english_capital: [
+                    ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P',],
+                    ['A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L',],
+                    ['Z', 'X', 'C', 'V', 'B', 'N', 'M', '\'', '.'],
+                    ['space', '-', 'backspace']
+                    ],
+            }
         });
     </script>
 </body>

--- a/lib/js/jkeyboard.js
+++ b/lib/js/jkeyboard.js
@@ -16,7 +16,10 @@
     var pluginName = "jkeyboard",
         defaults = {
             layout: "english",
-            input: $('#input')
+            input: $('#input'),
+            customLayouts: {
+                selectable: []
+            }
         };
 
 
@@ -116,6 +119,11 @@
         // is generally empty as we don't want to alter the default options for
         // future instances of the plugin
         this.settings = $.extend({}, defaults, options);
+        // Extend & Merge the cusom layouts
+        layouts = $.extend(true, {}, this.settings.customLayouts, layouts);
+        if (Array.isArray(this.settings.customLayouts.selectable)) {
+            $.merge(layouts.selectable, this.settings.customLayouts.selectable);
+        }
         this._defaults = defaults;
         this._name = pluginName;
         this.init();

--- a/lib/src/jkeyboard.js
+++ b/lib/src/jkeyboard.js
@@ -16,7 +16,10 @@
     var pluginName = "jkeyboard",
         defaults = {
             layout: "english",
-            input: $('#input')
+            input: $('#input'),
+            customLayouts: {
+                selectable: []
+            }
         };
 
 
@@ -116,6 +119,11 @@
         // is generally empty as we don't want to alter the default options for
         // future instances of the plugin
         this.settings = $.extend({}, defaults, options);
+        // Extend & Merge the cusom layouts
+        layouts = $.extend(true, {}, this.settings.customLayouts, layouts);
+        if (Array.isArray(this.settings.customLayouts.selectable)) {
+            $.merge(layouts.selectable, this.settings.customLayouts.selectable);
+        }
         this._defaults = defaults;
         this._name = pluginName;
         this.init();


### PR DESCRIPTION
Custom layout colors can now be added from initialization.
The following Options have been added to the configuration.

### customLayout - 
This option allows you add the custom layout to the Keyboard. The selected keyboard is still chosen from the `layout` option. 
 
Example
```
$('#keyboard').jkeyboard({
         layout: "english_capital",
         input: $('#search_field'),
         customLayouts: {
             selectable: ["english_capital"],
             english_capital: [
                    ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P',],
                    ['A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L',],
                    ['Z', 'X', 'C', 'V', 'B', 'N', 'M', '\'', '.'],
                    ['space', '-', 'backspace']
                    ],
           }
});

```