### PR TITLE
Modified Backspace function

### DIFF
--- a/lib/js/jkeyboard.js
+++ b/lib/js/jkeyboard.js
@@ -259,10 +259,20 @@
 
         backspace: function () {
             var input = this.settings.input,
-                val = input.val();
+                input_node = input.get(0),
+                start = input_node.selectionStart,
+                val = input.val();    
 
-            input.val(val.substr(0, val.length - 1));
-        },
+            if (start > 0) {
+                input.val(val.substring(0, start - 1) + val.substring(start));
+                input.trigger('focus');
+                input_node.setSelectionRange(start - 1, start - 1);
+            }
+            else {
+                input.trigger('focus');
+                input_node.setSelectionRange(0, 0);
+            }
+	    },
 
         toggleShiftOn: function () {
             var letters = $(this.element).find('.letter'),


### PR DESCRIPTION
Fixed the backspace function to make it function normally. Previously the back button moved the cursor to the beginning of the line, and/or always removed the character from the end of the line rather than the character in front of the cursor. 

This was referenced in issue #7 